### PR TITLE
Add missing rwunlock in constructor to avoid channel deadlock

### DIFF
--- a/audio_streamer_glue.cpp
+++ b/audio_streamer_glue.cpp
@@ -112,6 +112,8 @@ public:
             }
         });
 
+        switch_core_session_rwunlock(psession);
+
         // Now that our callback is setup, we can start our background thread and receive messages
         webSocket.start();
     }


### PR DESCRIPTION
Channels linger around when using mod_audio_stream is used. The console displays "Locked, Waiting on external entities" on hangup. 

This is a small fix to solve this issue.