### PR TITLE
This PR changes how mod_audio_stream attaches ASR JSON data to the event.

### DIFF
--- a/mod_audio_stream.c
+++ b/mod_audio_stream.c
@@ -15,7 +15,9 @@ static void responseHandler(switch_core_session_t* session, const char* eventNam
     switch_channel_t *channel = switch_core_session_get_channel(session);
     switch_event_create_subclass(&event, SWITCH_EVENT_CUSTOM, eventName);
     switch_channel_event_set_data(channel, event);
-    if (json) switch_event_add_body(event, "%s", json);
+    if (json) {
+        switch_event_add_header(event, SWITCH_STACK_BOTTOM, "AudioStream-ASR", json);
+    }
     switch_event_fire(&event);
 }
 


### PR DESCRIPTION
Currently the module uses:
```C
switch_event_add_body(event, "%s", json);
```
This adds the JSON payload into the event body, which makes it difficult for ESL clients and event routers to parse, because the body is not key-value structured and cannot be retrieved via event.get("key").
This PR replaces the body with a dedicated event header:
```C
switch_event_add_header(event, SWITCH_STACK_BOTTOM, "AudioStream-ASR", json);
```

Reasons for the change

1. Headers are key-value pairs
They can be retrieved directly using ESL’s event.get("AudioStream-ASR"), which is much easier and more reliable.

2. Body parsing is inconsistent
The body is appended after all headers and may contain arbitrary content and delimiters, making JSON extraction fragile.

3. Consistent with FreeSWITCH best practices
Most modules that deliver structured data (e.g., mod_json_cdr, mod_verto) use event headers instead of bodies.

4. Backward compatibility
Existing functionality is preserved; only the method of delivering the JSON payload is improved.